### PR TITLE
stav: extract information for the prover from the runner

### DIFF
--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1473,6 +1473,28 @@ impl CairoRunner {
             })
             .collect()
     }
+
+    pub fn get_info_for_prover_input(&self) -> Result<ProverInfo, RunnerError> {
+        Ok(ProverInfo {
+            relocatble_trace: self
+            .vm
+            .trace.clone()
+            .ok_or(RunnerError::Trace(TraceError::TraceNotEnabled))?,
+            relocatble_memory: self.vm.segments.memory.data.clone(),
+            public_memory_addresses: self.vm.segments.public_memory_offsets.clone(),
+            builtins_segments: self.get_builtin_segment_info_for_pie()?
+        })
+    }
+}
+
+//* ----------------------
+//*   ProverInfo
+//* ---------------------- 
+pub struct ProverInfo {
+    pub relocatble_trace: Vec<TraceEntry>,
+    pub relocatble_memory: Vec<Vec<MemoryCell>>,
+    pub public_memory_addresses: HashMap<usize, Vec<(usize, usize)>>,
+    pub builtins_segments: HashMap<BuiltinName, cairo_pie::SegmentInfo>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
# Crate ProverInfo from runner

## Description

In contrast to how we did it before (Stone), we want to use the data for Stwo while it's still relocatable and perform the relocation in the adapter. For this, we need the memory, trace, built-in segment information, and public memory addresses before they are relocated.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

