### PR TITLE
stavbe: change AirPrivateInputSerializable fields to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 * feat: Add support for subtractions containing references as right hand side operands [#1898](https://github.com/lambdaclass/cairo-vm/pull/1898)
 
+* chore: Expose fields in `AirPrivateInputSerializable` as public for external access [#1900] (https://github.com/lambdaclass/cairo-vm/pull/1900)
+
 * fix: Change wildcard getrandom dependency.
 
 * Update starknet-crypto to 0.7.3, removing the old FieldElement completly in favour of the new Felt (that is Copy).

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -12,8 +12,8 @@ use crate::Felt252;
 // Serializable format, matches the file output of the python implementation
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AirPrivateInputSerializable {
-    trace_path: String,
-    memory_path: String,
+    pub trace_path: String,
+    pub memory_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pedersen: Option<Vec<PrivateInput>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

